### PR TITLE
💚(circleci) ignore master branch in circleci changelog workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,13 +177,13 @@ workflows:
       - check-changelog:
           filters:
             branches:
-              ignore: main
+              ignore: master
             tags:
               only: /(?!^v).*/
       - lint-changelog:
           filters:
             branches:
-              ignore: main
+              ignore: master
             tags:
               only: /.*/
 


### PR DESCRIPTION
### Purpose

The changelog workflow should run on all branches except the master branch.

### Proposal

- [x] Update the circleci configuration.