### PR TITLE
🐛(cli) add support to nested problems and multi-line questions

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,4 +44,4 @@ async def test_api_convert(monkeypatch):
             "/convert", auth=("foo", "bar"), data={"content": content}
         )
         assert response.status_code == 200
-        assert response.content == b"::Q1::foo{"
+        assert response.content == b""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,23 +46,78 @@ def test_cli_convert_edx_2_gift():
         <responseparam type="tolerance" default=".1" />
         <formulaequationinput label="IGNORED" />
         </numericalresponse>
-        <h1>UNSUPPORTED</h1>
         </problem>
     """
 
-    expected = """::Q1::Multiple choice response question prompt ?{
+    expected = """::Q1::[html]<p>Multiple choice response question prompt ?</p>{
             =True
             ~False
         }
 
-        ::Q2::Choice response question prompt?{
-            ~%-1.00000%False
-            ~%0.50000%True 1
-            ~%0.50000%True 2
+        ::Q2::[html]<p>Choice response question prompt?</p>{
+            ~%-100%False
+            ~%50%True 1
+            ~%50%True 2
         }
 
-        ::Q3::Numerical response prompt?{#
+        ::Q3::[html]<p>Numerical response prompt?</p>{#
             =%100%1.2:0.1
+        }
+    """
+    expected = expected.replace(" " * 12, "\t").replace(" " * 4, "")
+    assert "".join(convert_edx_2_gift(xml)) == expected
+
+
+def test_cli_convert_edx_2_gift_with_nested_problem():
+    """Tests the convert_edx_2_gift function, given a nested problem, should yield the
+    expected result."""
+    xml = """
+        <problem>
+        <p>Multiple choice response question prompt ?</p>
+        <multiplechoiceresponse>
+            <choicegroup type="MultipleChoice" label="IGNORED">
+                <choice correct="true">True</choice>
+                <choice correct="false">False</choice>
+            </choicegroup>
+        </multiplechoiceresponse>
+
+        <problem>
+            <p>Multiple choice</p>
+            <p>question prompt ?</p>
+            <multiplechoiceresponse>
+                <choicegroup type="MultipleChoice" label="IGNORED">
+                    <choice correct="true">True</choice>
+                    <choice correct="false">False</choice>
+                </choicegroup>
+            </multiplechoiceresponse>
+        </problem>
+
+        <p>Choice response question prompt?</p>
+        <choiceresponse>
+        <checkboxgroup>
+            <choice correct="false">False </choice>
+            <choice correct="true">True 1</choice>
+            <choice correct="true">True 2</choice>
+        </checkboxgroup>
+        </choiceresponse>
+
+        </problem>
+    """
+
+    expected = """::Q1::[html]<p>Multiple choice response question prompt ?</p>{
+            =True
+            ~False
+        }
+
+        ::Q2::[html]<p>Multiple choice</p><p>question prompt ?</p>{
+            =True
+            ~False
+        }
+
+        ::Q3::[html]<p>Choice response question prompt?</p>{
+            ~%-100%False
+            ~%50%True 1
+            ~%50%True 2
         }
     """
     expected = expected.replace(" " * 12, "\t").replace(" " * 4, "")
@@ -83,6 +138,22 @@ def test_cli_cli(fs):
     """
     assert result.output == expected.replace(" " * 4, "")
 
-    fs.create_file("foo.xml", contents="<root><p>foo</p></root>")
+    xml = """
+        <problem>
+        <p>Numerical response prompt?</p>
+        <numericalresponse answer="1.2">
+        <responseparam type="tolerance" default=".1" />
+        <formulaequationinput label="IGNORED" />
+        </numericalresponse>
+        </problem>
+    """
+
+    expected = """::Q1::[html]<p>Numerical response prompt?</p>{#
+            =%100%1.2:0.1
+        }
+    """
+    expected = expected.replace(" " * 12, "\t").replace(" " * 4, "")
+
+    fs.create_file("foo.xml", contents=xml)
     result = runner.invoke(cli, ["foo.xml"])
-    assert result.output == "::Q1::foo{"
+    assert result.output == expected


### PR DESCRIPTION
### Purpose

We want to convert edX quizzes that contain nested problems and define their question on multiple lines.

### Proposal

- [x] Make the conversion function recursive
- [x] Include the edX HTML directly in the converted GIFT version
