### PR TITLE
🐛(cli) fix quiz with image error

### DIFF
--- a/edx2gift/cli.py
+++ b/edx2gift/cli.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)
 
 def escape_text(text: str) -> str:
     """Escapes special characters that are not allowed in GIFT format."""
+    if not text:
+        return ""
     for char in "~=#{}:":
         text = text.replace(char, f"\\{char}")
     return re.sub(" +", " ", text.replace("\n", " ")).strip()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -124,6 +124,31 @@ def test_cli_convert_edx_2_gift_with_nested_problem():
     assert "".join(convert_edx_2_gift(xml)) == expected
 
 
+def test_cli_convert_edx_2_gift_producing_invalid_results():
+    """Tests the convert_edx_2_gift function, given a not supported problem type, should
+    yield an invalid result."""
+    # Converting quizzes containg images is not supported.
+    xml = """
+        <problem>
+        <p>Choice response question prompt?</p>
+        <choiceresponse>
+        <checkboxgroup>
+            <choice correct="false"><img src="file_1"/></choice>
+            <choice correct="true"><img src="file_2"/></choice>
+        </checkboxgroup>
+        </choiceresponse>
+        </problem>
+    """
+
+    expected = """::Q1::[html]<p>Choice response question prompt?</p>{
+            ~%-100%
+            ~%100%
+        }
+    """
+    expected = expected.replace(" " * 12, "\t").replace(" " * 4, "")
+    assert "".join(convert_edx_2_gift(xml)) == expected
+
+
 def test_cli_cli(fs):
     """Tests the cli function."""
     # pylint: disable=invalid-name


### PR DESCRIPTION
### Purpose

The converter raises an exception when a quiz contains an image as a possible response.
We want the converter to continue execution, even if the result might be incorrect.
Such errors can be detected using a GIFT viewer and need manual intervention.

### Proposal

- [x] Ignore empty element-related errors.